### PR TITLE
Remove the line of code that calls the event unregistration in the On…

### DIFF
--- a/Assets/_Script/ManagerCtrl/PlayerManager/PlayerExperience.cs
+++ b/Assets/_Script/ManagerCtrl/PlayerManager/PlayerExperience.cs
@@ -15,11 +15,6 @@ public class PlayerExperience : LoboMonoBehaviour, IObserverListener
         ObserverManager.Instance.RegisterEvent(EventType.DogOnDead, this);
     }
 
-    private void OnDestroy()
-    {
-        ObserverManager.Instance.UnregisterEvent(EventType.DogOnDead, this);
-    }
-
     public void NotifyEvent(EventType type, object data)
     {
         DogData dogData = (DogData)data;

--- a/Assets/_Script/ManagerCtrl/PlayerManager/PlayerLevel.cs
+++ b/Assets/_Script/ManagerCtrl/PlayerManager/PlayerLevel.cs
@@ -20,12 +20,6 @@ public class PlayerLevel : LoboMonoBehaviour, IObserverListener
         this.ShowLevel();
     }
 
-    private void OnDestroy()
-    {
-        ObserverManager.Instance.UnregisterEvent(EventType.LevelUp, this);
-        ObserverManager.Instance.RegisterEvent(EventType.EnableShoppingMenuItemButton, this);
-    }
-
     public void NotifyEvent(EventType type, object data)
     {
         if(type == EventType.LevelUp) this.LevelUp();

--- a/Assets/_Script/ManagerCtrl/WaveManager.cs
+++ b/Assets/_Script/ManagerCtrl/WaveManager.cs
@@ -16,11 +16,6 @@ public class WaveManager : BaseSingleton<WaveManager>, IObserverListener
         ObserverManager.Instance.RegisterEvent(EventType.NextWave, this);
     }
 
-    private void OnDestroy()
-    {
-        ObserverManager.Instance.UnregisterEvent(EventType.NextWave, this);
-    }
-
     public void NotifyEvent(EventType type, object data)
     {
         this.NextWave();

--- a/Assets/_Script/ShieldSpawner/ShieldPrefabRepair.cs
+++ b/Assets/_Script/ShieldSpawner/ShieldPrefabRepair.cs
@@ -22,12 +22,6 @@ public class ShieldPrefabRepair : BaseShieldPrefab, IObserverListener
         ObserverManager.Instance.UnregisterEvent(EventType.DecreaseCoin, this);
     }
 
-    private void OnDestroy()
-    {
-        ObserverManager.Instance.UnregisterEvent(EventType.IncreaseCoin, this);
-        ObserverManager.Instance.UnregisterEvent(EventType.DecreaseCoin, this);
-    }
-
     public void NotifyEvent(EventType type, object data)
     {
         SetPlayerCoin((int)data);

--- a/Assets/_Script/ShieldSpawner/ShieldPrefabUpgrade.cs
+++ b/Assets/_Script/ShieldSpawner/ShieldPrefabUpgrade.cs
@@ -22,12 +22,6 @@ public class ShieldPrefabUpgrade : BaseShieldPrefab, IObserverListener
         ObserverManager.Instance.UnregisterEvent(EventType.DecreaseCoin, this);
     }
 
-    private void OnDestroy()
-    {
-        ObserverManager.Instance.UnregisterEvent(EventType.IncreaseCoin, this);
-        ObserverManager.Instance.UnregisterEvent(EventType.DecreaseCoin, this);
-    }
-
     public void NotifyEvent(EventType type, object data)
     {
         SetPlayerCoin((int)data);

--- a/Assets/_Script/SpawnerCtrl/BulletSpawner/BulletSpawner.cs
+++ b/Assets/_Script/SpawnerCtrl/BulletSpawner/BulletSpawner.cs
@@ -19,12 +19,6 @@ public class BulletSpawner : BaseSpawner, IObserverListener
         ObserverManager.Instance.RegisterEvent(EventType.BulletCollideWithDog, this);
     }
 
-    private void OnDestroy()
-    {
-        ObserverManager.Instance.UnregisterEvent(EventType.BulletDespawn, this);
-        ObserverManager.Instance.UnregisterEvent(EventType.BulletCollideWithDog, this);
-    }
-
     public void NotifyEvent(EventType type, object data)
     {
         BulletData bulletData = data as BulletData;

--- a/Assets/_Script/SpawnerCtrl/DogSpawner/DogAnimation.cs
+++ b/Assets/_Script/SpawnerCtrl/DogSpawner/DogAnimation.cs
@@ -15,11 +15,6 @@ public class DogAnimation : BaseAnimation, IObserverListener
         ObserverManager.Instance.UnregisterEvent(EventType.DogOnDead, this);
     }
 
-    private void OnDestroy()
-    {
-        ObserverManager.Instance.UnregisterEvent(EventType.DogOnDead, this);
-    }
-
     public void NotifyEvent(EventType type, object data)
     {
         DogData dogData = (DogData)data;

--- a/Assets/_Script/SpawnerCtrl/DogSpawner/DogSpawner.cs
+++ b/Assets/_Script/SpawnerCtrl/DogSpawner/DogSpawner.cs
@@ -23,11 +23,6 @@ public class DogSpawner : BaseSpawner, IObserverListener
         ObserverManager.Instance.RegisterEvent(EventType.DogOnDead, this);
     }
 
-    private void OnDestroy()
-    {
-        ObserverManager.Instance.UnregisterEvent(EventType.DogOnDead, this);
-    }
-
     public void NotifyEvent(EventType type, object data)
     {
         DogData dogData = (DogData)data;

--- a/Assets/_Script/UI/DragAndDrop/UISpawnerCtrl/ChickenSpawner/ChickenSpawner.cs
+++ b/Assets/_Script/UI/DragAndDrop/UISpawnerCtrl/ChickenSpawner/ChickenSpawner.cs
@@ -13,11 +13,6 @@ public class ChickenSpawner : BaseSpawner, IObserverListener
         ObserverManager.Instance.RegisterEvent(EventType.BuyChicken, this);
     }
 
-    private void OnDestroy()
-    {
-        ObserverManager.Instance.UnregisterEvent(EventType.BuyChicken, this);
-    }
-
     public void NotifyEvent(EventType type, object data)
     {
         ChickenZeroSpawnInLobby();

--- a/Assets/_Script/UI/GameplayScreen/BottomScreen/BuyChickenButton/BuyChickenButtonOff.cs
+++ b/Assets/_Script/UI/GameplayScreen/BottomScreen/BuyChickenButton/BuyChickenButtonOff.cs
@@ -14,9 +14,4 @@ public class BuyChickenButtonOff : LoboMonoBehaviour, IObserverListener
         ObserverManager.Instance.RegisterEvent(EventType.DisableChickenButtonOn, this);
     }
 
-    private void OnDestroy()
-    {
-        ObserverManager.Instance.UnregisterEvent(EventType.DisableChickenButtonOn, this);
-    }
-
 }

--- a/Assets/_Script/UI/GameplayScreen/BottomScreen/BuyChickenButton/BuyChickenButtonOn.cs
+++ b/Assets/_Script/UI/GameplayScreen/BottomScreen/BuyChickenButton/BuyChickenButtonOn.cs
@@ -12,11 +12,6 @@ public class BuyChickenButtonOn : BaseButton, IObserverListener
         ObserverManager.Instance.RegisterEvent(EventType.DecreaseCoin, this);
     }
 
-    private void OnDestroy()
-    {
-        ObserverManager.Instance.UnregisterEvent(EventType.DecreaseCoin, this);
-    }
-
     protected override void OnClick()
     {
         ObserverManager.Instance.NotifyEvent(EventType.BuyChicken, _chickenPrice);

--- a/Assets/_Script/UI/GameplayScreen/BottomScreen/BuyChickenButton/ChickenPriceTextButtonOff.cs
+++ b/Assets/_Script/UI/GameplayScreen/BottomScreen/BuyChickenButton/ChickenPriceTextButtonOff.cs
@@ -10,11 +10,6 @@ public class ChickenPriceTextButtonOff : BaseText, IObserverListener
         ObserverManager.Instance.RegisterEvent(EventType.DisableChickenButtonOn, this);
     }
 
-    private void OnDestroy()
-    {
-        ObserverManager.Instance.UnregisterEvent(EventType.DisableChickenButtonOn, this);
-    }
-
     public void NotifyEvent(EventType type, object data)
     {
         int chickenPrice = (int)data;

--- a/Assets/_Script/UI/GameplayScreen/TopScreen/CoinText.cs
+++ b/Assets/_Script/UI/GameplayScreen/TopScreen/CoinText.cs
@@ -12,11 +12,6 @@ public class CoinText : BaseText, IObserverListener
         ObserverManager.Instance.RegisterEvent(EventType.ShowCoin, this);
     }
 
-    private void OnDestroy()
-    {
-        UnregisterEvent();
-    }
-
     public void NotifyEvent(EventType type, object data)
     {
         int coin = (int)data;
@@ -28,8 +23,4 @@ public class CoinText : BaseText, IObserverListener
         this.text.text = coin.ToString();
     }
 
-    public void UnregisterEvent()
-    {
-        ObserverManager.Instance.UnregisterEvent(EventType.ShowCoin, this);
-    }
 }

--- a/Assets/_Script/UI/GameplayScreen/TopScreen/UserInfo/LevelExp.cs
+++ b/Assets/_Script/UI/GameplayScreen/TopScreen/UserInfo/LevelExp.cs
@@ -12,12 +12,6 @@ public class LevelExp : BaseSlider, IObserverListener
         ObserverManager.Instance.RegisterEvent(EventType.ShowExp, this);
     }
 
-    private void OnDestroy()
-    {
-        ObserverManager.Instance.UnregisterEvent(EventType.LevelUp, this);
-        ObserverManager.Instance.UnregisterEvent(EventType.ShowExp, this);
-    }
-
     public void NotifyEvent(EventType type, object data)
     {
         float value = (float)data;

--- a/Assets/_Script/UI/GameplayScreen/TopScreen/UserInfo/LevelText.cs
+++ b/Assets/_Script/UI/GameplayScreen/TopScreen/UserInfo/LevelText.cs
@@ -10,11 +10,6 @@ public class LevelText : BaseText, IObserverListener
         ObserverManager.Instance.RegisterEvent(EventType.ShowLevel, this);
     }
 
-    private void OnDestroy()
-    {
-        ObserverManager.Instance.UnregisterEvent(EventType.ShowLevel, this);    
-    }
-
     public void NotifyEvent(EventType type, object data)
     {
         int level = (int)data;

--- a/Assets/_Script/UI/GameplayScreen/TopScreen/WaveText.cs
+++ b/Assets/_Script/UI/GameplayScreen/TopScreen/WaveText.cs
@@ -9,11 +9,6 @@ public class WaveText : BaseText, IObserverListener
         ObserverManager.Instance.RegisterEvent(EventType.ShowWaveText, this);
     }
 
-    private void OnDestroy()
-    {
-        ObserverManager.Instance.UnregisterEvent(EventType.ShowWaveText, this);
-    }
-
     public void NotifyEvent(EventType type, object data)
     {
         this.ShowWaveText((int)data);


### PR DESCRIPTION
In this project, the observer design pattern is used to manage the events. An instance of ObserverManager is required to invoke the Unregister method on behalf of an object acting as a listener in order to unregister from an event for which it had previously registered. Because the ObserverManager instance may also be destroyed in the OnDestroy method, calling an instance in the OnDestroy method is likely to result in an error.